### PR TITLE
docs: align README with org template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 StoryTime Productions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,121 +1,57 @@
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-
 <a id="readme-top"></a>
 
-<!--
-*** Thanks for checking out NugGunRun! If you have a suggestion
-*** that would make this better, please fork the repo and create a pull request
-*** or simply open an issue with the tag "enhancement".
-*** Don't forget to give the project a star!
-*** Thanks again! Now go create something AMAZING! :D
--->
-
-<!-- PROJECT SHIELDS -->
-<!--
-*** I'm using markdown "reference style" links for readability.
-*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
-*** See the bottom of this document for the declaration of the reference variables
-*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
-*** https://www.markdownguide.org/basic-syntax/#reference-style-links
--->
-
-<!-- PROJECT SHIELDS -->
 <p align="center">
-  <a href="https://github.com/StoryTime-Productions/NugRunGun/graphs/contributors">
-    <img src="https://img.shields.io/github/contributors/StoryTime-Productions/NugRunGun.svg?style=for-the-badge" alt="Contributors">
-  </a>
-  <a href="https://github.com/StoryTime-Productions/NugRunGun/network/members">
-    <img src="https://img.shields.io/github/forks/StoryTime-Productions/NugRunGun.svg?style=for-the-badge" alt="Forks">
-  </a>
-  <a href="https://github.com/StoryTime-Productions/NugRunGun/stargazers">
-    <img src="https://img.shields.io/github/stars/StoryTime-Productions/NugRunGun.svg?style=for-the-badge" alt="Stars">
-  </a>
-  <a href="https://github.com/StoryTime-Productions/NugRunGun/issues">
-    <img src="https://img.shields.io/github/issues/StoryTime-Productions/NugRunGun.svg?style=for-the-badge" alt="Issues">
-  </a>
+  <img src="https://i.imgur.com/PQcrqRh.png" alt="NugRunGun banner" />
 </p>
 
+<p align="center">
+  <img src="https://img.shields.io/badge/Engine-Unity-blueviolet" alt="Unity" />
+  <!-- TODO: fill in exact Unity version (ProjectSettings/ProjectVersion.txt not present in this clone) -->
+</p>
 
-<!-- PROJECT LOGO -->
-<br />
-<div align="center">
-  <a href="https://github.com/StoryTime-Productions/NugRunGun">
-    <img src="https://i.imgur.com/PQcrqRh.png" alt="Logo">
-  </a>
+<p align="center">
+  <a href="https://storytime-productions.itch.io/nugrungun">Download Game</a>
+  ·
+  <a href="https://github.com/StoryTime-Productions/NugRunGun/issues/new?template=1-fix.md">Report Bug</a>
+  ·
+  <a href="https://github.com/StoryTime-Productions/NugRunGun/issues/new?template=2-feature.md">Request Feature</a>
+</p>
 
-  <h3 align="center">NugRunGun</h3>
+Shoot food as a nugget with sick DnB tracks. NugRunGun is a fast-paced, top-down arcade shooter where you face off against waves of enemy food items across three differently themed levels, surviving until the end of each level's music track while maximizing your score through powerups and combo mastery.
 
-  <p align="center">
-    Shoot food as a nugget with sick DnB tracks
-    <br />
-    <br />
-    <a href="https://storytime-productions.itch.io/nugrungun">Download Game</a>
-    ·
-    <a href="https://github.com/StoryTime-Productions/NugRunGun/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
-    ·
-    <a href="https://github.com/StoryTime-Productions/NugRunGun/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
-  </p>
-</div>
-
-<!-- TABLE OF CONTENTS -->
-<details>
-  <summary>Table of Contents</summary>
-  <ol>
-    <li>
-      <a href="#about-the-project">About The Project</a>
-      <ul>
-        <li><a href="#built-with">Built With</a></li>
-      </ul>
-    </li>
-    <li><a href="#gameplay">Gameplay</a></li>
-    <li><a href="#reporting-issues">Reporting Issues</a></li>
-    <li><a href="#contact">Contact</a></li>
-    <li><a href="#acknowledgments">Acknowledgments</a></li>
-  </ol>
-</details>
-
-<!-- ABOUT THE PROJECT -->
 ## About The Project
+
 <p align="center">
   <img src="https://github.com/user-attachments/assets/795dce49-8e3c-4550-9f1c-9149ce375873" alt="ScreenShot4" width="32%" />
   <img src="https://github.com/user-attachments/assets/11fbd057-0f9e-4e17-a19e-728307f8856a" alt="ScreenShot1" width="32%" />
   <img src="https://github.com/user-attachments/assets/12c54447-409c-4c91-9e3c-947fb7e5c1f3" alt="ScreenShot3" width="32%" />
 </p>
-<br>
-For too long has the chicken nugget been at the bottom. Equipped with an arsenal, it's time to show 'em how fried you are! NugGunRun is a fast-paced, top-down arcade shooter where you face off against waves of enemy food items across three differently themed levels. Survive until the end of each level's music track while maximizing your score through powerups and combo mastery.
 
-## What's in it for you?
+For too long has the chicken nugget been at the bottom. Equipped with an arsenal, it's time to show 'em how fried you are! NugRunGun pits you against waves of enemy food items across three differently themed levels, each built around the duration of its own DnB music track.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Gameplay
+
+The game contains three differently themed levels in which you face off against waves of enemy food items for the duration of the level's music track. Survive until the end and maximize your score using powerups and maintaining a combo. Oh, and don't forget to pick up the health packs.
+
+### Controls
+
+| Action | Input |
+|--------|-------|
+| Move | WASD |
+| Aim and shoot | Mouse |
+| Reload | R |
+| Switch weapons | Q |
+| Pause menu | Esc |
+
+### Features
 
 - **Combo-based Audio Layering** - Rack up combos from "Raw" to "Nugget God" to progressively unlock music layers (DnB!)
 - **Mix of Weapons** - Switch between differently configured weapons based on your preferred playstyle
 - **Chicken Allies** - Never forget where you came from. Spawn chickens to help you beat competing food
 - **Powerups Galore** - Grab temporary invulnerability, speed boost, and damage multiplier to deep-fry your marksmanship
 - **Get Tougher** - Higher combos reduce damage by up to 30%, helping you survive longer
-
-## How does this game go?
-
-The game contains three differently themed levels in which you face off against waves of enemy food items for the duration of the level's music track. Survive until the end and maximize your score using powerups and maintaining a combo. Oh, and don't forget to pickup the health packs...
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-## Built With
-- [![Unity][Unity.com]][Unity-url]
-- [![CSharp][CSharp.dev]][CSharp-url]
-- [![Cinemachine][Cinemachine.dev]][Cinemachine-url]
-- [![InputSystem][InputSystem.dev]][InputSystem-url]
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<!-- GETTING STARTED -->
-## Gameplay
-
-### Controls
-
-- **WASD** - Move
-- **Mouse** - Aim and shoot
-- **R** - Reload
-- **Q** - Switch weapons
-- **Esc** - Pause menu
 
 ### Combat System
 
@@ -144,13 +80,38 @@ Each level is designed around its music track duration - survive until the end w
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+## Built With
+
+- Unity <!-- TODO: fill in exact version, e.g. from ProjectSettings/ProjectVersion.txt -->
+- C#
+- Cinemachine
+- Unity Input System
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Getting Started
+
+### Prerequisites
+
+- Unity Editor <!-- TODO: fill in exact version required to open the project -->
+
+### Installing / Running
+
+The easiest way to play is to grab the latest build from itch.io:
+
+- [Download NugRunGun on itch.io](https://storytime-productions.itch.io/nugrungun)
+
+<!-- TODO: add instructions for building/running the project from source, if applicable -->
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 ## Reporting Issues
 
 Found a bug or have a feature request? We'd love to hear from you!
 
-### 🐛 Bug Reports
+### Bug Reports
 
-Use our [Bug Report Template](https://github.com/StoryTime-Productions/NugRunGun/issues/new?labels=bug&template=bug-report---.md) and include:
+Use our [Fix issue template](https://github.com/StoryTime-Productions/NugRunGun/issues/new?template=1-fix.md) and include:
 
 - Unity version
 - Operating system
@@ -158,9 +119,9 @@ Use our [Bug Report Template](https://github.com/StoryTime-Productions/NugRunGun
 - Expected vs actual behavior
 - Screenshots/videos if applicable
 
-### 💡 Feature Requests
+### Feature Requests
 
-Use our [Feature Request Template](https://github.com/StoryTime-Productions/NugRunGun/issues/new?labels=enhancement&template=feature-request---.md) and describe:
+Use our [Feature issue template](https://github.com/StoryTime-Productions/NugRunGun/issues/new?template=2-feature.md) and describe:
 
 - The problem you're solving
 - Your proposed solution
@@ -168,8 +129,6 @@ Use our [Feature Request Template](https://github.com/StoryTime-Productions/NugR
 - Additional context or mockups
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<!-- CONTACT -->
 
 ## Contact
 
@@ -179,11 +138,9 @@ Project Link: [itch.io Page](https://storytime-productions.itch.io/nugrungun)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-<!-- ACKNOWLEDGMENTS -->
-
 ## Acknowledgments
 
-Special thanks to these resources and communities that made NugGunRun possible:
+Special thanks to these resources and communities that made NugRunGun possible:
 
 - [Unity Documentation](https://docs.unity3d.com/)
 - [Unity Asset Store](https://assetstore.unity.com/)
@@ -194,27 +151,6 @@ Special thanks to these resources and communities that made NugGunRun possible:
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-<!-- MARKDOWN LINKS & IMAGES -->
-<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+## License
 
-[contributors-shield]: https://img.shields.io/github/contributors/StoryTime-Productions/NugRunGun.svg?style=for-the-badge
-[contributors-url]: https://github.com/StoryTime-Productions/NugRunGun/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/StoryTime-Productions/NugRunGun.svg?style=for-the-badge
-[forks-url]: https://github.com/StoryTime-Productions/NugRunGun/network/members
-[stars-shield]: https://img.shields.io/github/stars/StoryTime-Productions/NugRunGun.svg?style=for-the-badge
-[stars-url]: https://github.com/StoryTime-Productions/NugRunGun/stargazers
-[issues-shield]: https://img.shields.io/github/issues/StoryTime-Productions/NugRunGun.svg?style=for-the-badge
-[issues-url]: https://github.com/StoryTime-Productions/NugRunGun/issues
-[license-shield]: https://img.shields.io/github/license/StoryTime-Productions/NugRunGun.svg?style=for-the-badge
-[license-url]: https://github.com/StoryTime-Productions/NugRunGun/blob/master/LICENSE.txt
-[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
-[linkedin-url]: https://linkedin.com/in/storytimeproductions
-[product-screenshot]: Assets/Screenshots/gameplay_screenshot.png
-[Unity.com]: https://img.shields.io/badge/Unity-000000?style=for-the-badge&logo=unity&logoColor=white
-[Unity-url]: https://unity.com/
-[CSharp.dev]: https://img.shields.io/badge/C%23-239120?style=for-the-badge&logo=c-sharp&logoColor=white
-[CSharp-url]: https://docs.microsoft.com/en-us/dotnet/csharp/
-[Cinemachine.dev]: https://img.shields.io/badge/Cinemachine-FF6B35?style=for-the-badge&logo=unity&logoColor=white
-[Cinemachine-url]: https://unity.com/unity/features/editor/art-and-design/cinemachine
-[InputSystem.dev]: https://img.shields.io/badge/Input%20System-4FC3F7?style=for-the-badge&logo=unity&logoColor=white
-[InputSystem-url]: https://docs.unity3d.com/Packages/com.unity.inputsystem@1.4/manual/index.html
+MIT - see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Align README.md with the org's game-readme template (org-github/templates/game-readme.md)
- Drop the H1 title since the banner image already shows the wordmark
- Add missing LICENSE file (MIT)